### PR TITLE
remove default 100MB cache dir and lower disk space of extra one

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ squid_internal_net: "{{ internal_net | default() }}"
 squid_default_cache_dir: "/var/spool/squid"
 # cache_dir ufs /squid/cache  100000 16 256
 squid_extra_cache_dir: True
-squid_cache_dir2: { path: "/squid/cache", MB: 100000, L1: 16, L2: 256 }
+squid_cache_dir2: { path: "/squid/cache", MB: 30000, L1: 16, L2: 256 }
 squid_block_yum_metadata: True
 squid_allow_snmp_local: True
 squid_cache_local: True

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -84,7 +84,6 @@ refresh_pattern .		0	20%	4320
 
 ### Additions
 
-cache_dir ufs {{ squid_default_cache_dir }} 100 16 256
 {% if squid_extra_cache_dir %}
 cache_dir ufs {{ squid_cache_dir2["path"] }} {{ squid_cache_dir2["MB"] }} {{ squid_cache_dir2["L1"] }} {{ squid_cache_dir2["L2"] }}
 {% endif %}


### PR DESCRIPTION
- resulting in only one cache_dir ufs of 30GB

https://github.com/CSC-IT-Center-for-Science/fgci-ansible/issues/143
