### PR TITLE
Selinux support for ansible-role-squid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,3 @@ squid_cache_local: True
 # set new settings by defining squid_extra_settings list. The example below changes timestamp in the access log to human readable timestamp from GMT (%tg instead of %ts)
 #squid_extra_settings:
 #  - "logformat squid      %tg.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt"
-squid_selinux_files: "/squid/cache(/.*)?"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ squid_cache_local: True
 # set new settings by defining squid_extra_settings list. The example below changes timestamp in the access log to human readable timestamp from GMT (%tg instead of %ts)
 #squid_extra_settings:
 #  - "logformat squid      %tg.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt"
+squid_selinux_files: "/squid/cache(/.*)?"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -25,15 +25,15 @@
 
 - name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
-  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
+  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Allow squid to use extra cache dir (2/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
-  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
+  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Set correct context for extra cache dir"
   command: restorecon -R {{ squid_cache_dir2["path"] }} 
-  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
+  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
 
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -21,15 +21,19 @@
         proto: "udp"
         setype: "squid_port_t"
         state: present
+  when: ansible_selinux.status == "enabled"
 
-- name: "SELinux: Allow squid to use extra cache dir"
+- name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
+  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
+
+- name: "SELinux: Allow squid to use extra cache dir (2/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
-  when: squid_extra_cache_dir
+  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
 
 - name: "SELinux: Set correct context for extra cache dir"
   command: restorecon -R {{ squid_cache_dir2["path"] }} 
-  when: squid_extra_cache_dir
+  when: squid_extra_cache_dir && ansible_selinux.status == "enabled"
 
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -11,6 +11,16 @@
   file: path={{ squid_cache_dir2["path"] }} state=directory owner=squid group=squid mode=0755
   when: squid_extra_cache_dir
 
+- sefcontext: 
+        name: Set SELinux context for squid cache dir
+        target: {{ squid_cache_dir2 }}/(.*)?
+        setype: squid_cache_t
+        state: present
+        reload: yes
+        seuser: system_u
+        serange: object_r
+  when: squid_extra_cache_dir
+
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes
   notify:
@@ -30,3 +40,4 @@
 - name: Wait for squid port to come up
   wait_for: port=3128 timeout=60 host=0.0.0.0
   when: ansible_virtualization_type != "docker"
+

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -26,17 +26,17 @@
 - name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Allow squid to use extra cache dir (2/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Set correct context for extra cache dir"
   command: restorecon -R {{ squid_cache_dir2["path"] }} 
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -21,7 +21,7 @@
         proto: "udp"
         setype: "squid_port_t"
         state: present
-  when: ansible_selinux.status == "enabled"
+  when: (ansible_selinux != false ) and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -26,17 +26,17 @@
 - name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Allow squid to use extra cache dir (2/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Set correct context for extra cache dir"
   command: restorecon -R {{ squid_cache_dir2["path"] }} 
   run_once: true
-  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
+  when: squid_extra_cache_dir is defined and ( ansible_selinux != false )  and ( ansible_selinux.status == "enabled" )
 
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,6 +4,10 @@
 - name: "Install squid"
   yum: name=squid state=latest
 
+- name: "Install policycoreutils-python"
+  yum: name=policycoreutils-python state=latest
+  when: squid_extra_cache_dir
+
 - name: "Install ss from package iproute"
   yum: name=iproute state=latest
 
@@ -11,14 +15,20 @@
   file: path={{ squid_cache_dir2["path"] }} state=directory owner=squid group=squid mode=0755
   when: squid_extra_cache_dir
 
-- sefcontext: 
-        name: Set SELinux context for squid cache dir
-        target: {{ squid_cache_dir2 }}/(.*)?
-        setype: squid_cache_t
+- name: "SELinux: Allow squid to use SNMP UDP port"
+  seport:
+        ports: 161
+        proto: "udp"
+        setype: "squid_port_t"
         state: present
-        reload: yes
-        seuser: system_u
-        serange: object_r
+
+- name: "SELinux: Allow squid to use extra cache dir"
+  command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
+  command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
+  when: squid_extra_cache_dir
+
+- name: "SELinux: Set correct context for extra cache dir"
+  command: restorecon -R {{ squid_cache_dir2["path"] }} 
   when: squid_extra_cache_dir
 
 - name: "Template in squid.conf"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -25,15 +25,18 @@
 
 - name: "SELinux: Allow squid to use extra cache dir (1/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}(/.*?)'
-  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
+  run_once: true
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Allow squid to use extra cache dir (2/2)"
   command: /usr/sbin/semanage fcontext -a -t squid_cache_t '{{ squid_cache_dir2["path"]}}'
-  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
+  run_once: true
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
 
 - name: "SELinux: Set correct context for extra cache dir"
   command: restorecon -R {{ squid_cache_dir2["path"] }} 
-  when: squid_extra_cache_dir and ansible_selinux and ( ansible_selinux.status == "enabled" )
+  run_once: true
+  when: squid_extra_cache_dir is defined and ansible_selinux is defined and ansible_selinux.status is defined  and ( ansible_selinux.status == "enabled" )
 
 - name: "Template in squid.conf"
   template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=squid mode=0640 backup=yes


### PR DESCRIPTION
This PR adds two parts to enable ansible-role-squid to run with SELinux enabled:

- allow usage of UDP/161 (snmp port)
- set a proper context for the extra cache directory.