### PR TITLE
Support for limiting outgoing traffic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,19 @@ squid_cache_dir2: { path: "/squid/cache", MB: 30000, L1: 16, L2: 256 }
 squid_block_yum_metadata: True
 squid_allow_snmp_local: True
 squid_cache_local: True
+
+# For limiting outgoing traffic
+
+squid_limit_outgoing_traffic: False
+
+# If you limit outgoing traffic, you can limit either domains, ips or both
+#squid_allowed_outgoing_domains:
+#  - example.com
+#  - other.example.com
+
+#squid_allowed_outgoing_ips:
+#  - 1.2.3.4
+
 # set new settings by defining squid_extra_settings list. The example below changes timestamp in the access log to human readable timestamp from GMT (%tg instead of %ts)
 #squid_extra_settings:
 #  - "logformat squid      %tg.%03tu %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt"

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -34,6 +34,18 @@ acl Safe_ports port 591		# filemaker
 acl Safe_ports port 777		# multiling http
 acl CONNECT method CONNECT
 
+# Add optional acls for outgoing traffic restictions
+{% if squid_allowed_outgoing_domains is defined %}
+{% for outgoing_domain in squid_allowed_outgoing_domains %}
+acl outgoing_domains dstdomain {{ outgoing_domain }}
+{% endfor %}
+{% endif %}
+{% if squid_allowed_outgoing_ips is defined %}
+{% for outgoing_ip in squid_allowed_outgoing_ips %}
+acl outgoing_ips dst {{ outgoing_ip }}
+{% endfor %}
+{% endif %}
+
 #
 # Recommended minimum Access Permission configuration:
 #
@@ -59,7 +71,19 @@ http_access deny manager
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
+{% if internal_net %}
+{% if squid_limit_outgoing_traffic %}
+{% if squid_allowed_outgoing_domains is defined %}
+http_access allow localnet outgoing_domains
+{% endif %}
+{% if squid_allowed_outgoing_ips is defined %}
+http_access allow localnet outgoing_ips
+{% endif %}
+{% else %}
 http_access allow localnet
+{% endif %}
+{% endif %}
+
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,10 @@
 
  - hosts: localhost
    remote_user: root
+   vars:
+    - squid_limit_outgoing_traffic: True
+    - squid_allowed_outgoing_domains: [ example.com ]
+    - squid_allowed_outgoing_ips: [ 8.8.8.8 ]
+
    roles:
      - ansible-role-squid


### PR DESCRIPTION
Added options for limiting outgoing traffic to allow traffic only to a
whitelisted subset of domains/IPs.

The default functionality did not change.