### PR TITLE
Normalize YAML and deduplicate code

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 # defaults file for ansible-role-squid
+
+squid_package_state: "present"
+
 internal_net: ""
 squid_internal_net: "{{ internal_net | default() }}"
 squid_default_cache_dir: "/var/spool/squid"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -8,7 +8,7 @@
 
 - name: "Set up extra cache dir"
   file:
-    path: "{{ squid_cache_dir2["path"] }}"
+    path: "{{ squid_cache_dir2.path }}"
     state: directory
     owner: proxy
     group: proxy

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,33 +1,28 @@
 ---
 # tasks file for ansible-role-squid
 
-- name: "Install squid"
-  apt: name=squid state=latest
-
-- name: "Install iproute2"
-  apt: name=iproute2 state=latest
+- name: "Install iproute2 on Debian"
+  apt:
+    name: iproute2
+    state: "{{ squid_package_state }}"
 
 - name: "Set up extra cache dir"
-  file: path={{ squid_cache_dir2["path"] }} state=directory owner=proxy group=proxy mode=0755
+  file:
+    path: "{{ squid_cache_dir2["path"] }}"
+    state: directory
+    owner: proxy
+    group: proxy
+    mode: 0755
   when: squid_extra_cache_dir
 
 - name: "Template in squid.conf"
-  template: src=squid.conf.j2 dest=/etc/squid/squid.conf owner=root group=proxy mode=0640 backup=yes
+  template:
+    src: squid.conf.j2
+    dest: /etc/squid/squid.conf
+    owner: root
+    group: proxy
+    mode: 0640
+    backup: yes
   notify:
    - restart squid
-
-- name: "is squid listening?"
-  command: ss -lntu
-  register: squid_ss_output
-  check_mode: no
-  changed_when: False
-
-- debug: var=squid_ss_output verbosity=1
-
-- name: Wait for squid port to come up
-  wait_for:
-    port: 3128
-    timeout: 60
-    host: 0.0.0.0
-  when: ansible_virtualization_type != "docker"
-
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,31 @@
 ---
 # tasks file for ansible-role-squid
 
+- name: "Install squid"
+  package: 
+    name: squid 
+    state: "{{ squid_package_state }}"
+
 - include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
 
 - include_tasks: debian.yml
   when: ansible_os_family == "Debian"
+
+- name: "is squid listening?"
+  command: ss -lntu
+  register: squid_ss_output
+  check_mode: no
+  changed_when: False
+
+- debug:
+    var: squid_ss_output
+    verbosity: 1
+
+- name: Wait for squid port to come up
+  wait_for:
+    port: 3128
+    timeout: 60
+    host: 0.0.0.0
+  when: ansible_virtualization_type != "docker"
+...

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,13 +1,12 @@
 ---
 # tasks file for ansible-role-squid
 
-- name: "Install required packages"
+- name: "Install required packages on redhat"
   yum: 
     name: 
-      - squid 
       - policycoreutils-python
       - iproute
-    state: latest
+    state: "{{ squid_package_state }}"
 
 - name: "Set up extra cache dir"
   file:
@@ -65,19 +64,4 @@
     name: squid
     state: started
     enabled: yes
-
-- name: "is squid listening?"
-  command: ss -lntu
-  register: squid_ss_output
-  check_mode: no
-  changed_when: False
-
-- debug: var=squid_ss_output verbosity=1
-
-- name: Wait for squid port to come up
-  wait_for:
-    port: 3128
-    timeout: 60
-    host: 0.0.0.0
-  when: ansible_virtualization_type != "docker"
-
+...

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -9,18 +9,17 @@ RUN yum clean all && \
     yum -y groups mark convert "Development Tools" && \
     yum -y groupinstall "Development Tools" && \
     yum -y install libffi-devel openssl-devel && \
+    yum -y install dbus-devel dbus-python-devel dbus dbus-glib dbus-glib-devel && \
     yum -y install python-devel MySQL-python sshpass && \
     yum -y install acl sudo && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
-    pip install --upgrade pip && \
-    pip install requests[security] && \
-    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    pip install pysphere passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \
     yum -y autoremove && \
-    yum -y install bzip2 file findutils gem git gzip hg iproute procps-ng svn sudo tar tree which unzip xz zip && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip && \
     yum clean all && rm -rf /var/cache/yum
 
 RUN mkdir /etc/ansible/
@@ -28,6 +27,8 @@ RUN echo -e '[local]\nlocalhost\n' > /etc/ansible/hosts
 RUN mkdir /opt/ansible/
 RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
 WORKDIR /opt/ansible/ansible
+# here one could checkout a specific commit
+#RUN git checkout f4af154beff2b281e464b616f504293d67187da5
 RUN git submodule update --init
 ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
 ENV PYTHONPATH /opt/ansible/ansible/lib


### PR DESCRIPTION
 - No longer set packages as "latest" but to installed. Let some other
   tool update/auto-update packages
 - YAML syntax is now the same in all the tasks
 - Moved squid package installation into main.yml
 - Moved final verification that squid is listening to main.yml
 - Made some task names clearer

one travis test still fails because that old pip certificate 10.0 pypi.org crap. The other tests with EPEL and pip in Ubuntu work.