### PR TITLE
Add support for CentOS8/RHEL8

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,12 +1,21 @@
 ---
 # tasks file for ansible-role-squid
 
-- name: "Install required packages on redhat"
+- name: "Install required packages on CentOS7/RHEL7"
   yum: 
     name: 
       - policycoreutils-python
       - iproute
     state: "{{ squid_package_state }}"
+  when: ansible_distribution_version == "7"
+
+- name: "Install required packages on CentOS8/RHEL8"
+  dnf: 
+    name: 
+      - python3-policycoreutils
+      - iproute
+    state: "{{ squid_package_state }}"
+  when: ansible_distribution_version == "8"
 
 - name: "Set up extra cache dir"
   file:


### PR DESCRIPTION
This change adds support for CentOS8 (Stream) and probably other RHEL 8-compatible distributions.

Tested to be functional on CentOS 8 Stream, should be still backwards compatible for CentOS 7.