### PR TITLE
Fixes for alma9

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,6 +9,3 @@
   ansible.builtin.service:
     name: "squid3"
     state: restarted
-
-- name: "Set correct context"
-  ansible.builtin.command: restorecon -R {{ squid_cache_dir2["path"] }} # noqa: no-changed-when

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -41,7 +41,7 @@
     setype: "squid_port_t"
     state: present
   when:
-    - ansible_selinux is false
+    - ansible_selinux is defined
     - ansible_selinux.status == "enabled"
 
 - name: "SELinux: Allow squid to use extra cache dir"
@@ -52,7 +52,7 @@
     state: "{{ squid_extra_cache_dir | ternary('present', 'absent') }}"
   register: register_sefcontext
   when:
-    - ansible_selinux is false
+    - ansible_selinux is defined
     - ansible_selinux.status == "enabled"
   notify:
     - Set correct context

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,14 +1,6 @@
 ---
 # tasks file for ansible-role-squid
 
-- name: "Install required packages on CentOS7/RHEL7"
-  ansible.builtin.yum:
-    name:
-      - policycoreutils-python
-      - iproute
-    state: "{{ squid_package_state }}"
-  when: ansible_distribution_major_version == "7"
-
 - name: "Install required packages on CentOS8/RHEL8"
   ansible.builtin.dnf:
     name:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -50,12 +50,13 @@
     setype: squid_cache_t
     target: "{{ squid_cache_dir2['path'] }}(/.*)?"
     state: "{{ squid_extra_cache_dir | ternary('present', 'absent') }}"
-  register: register_sefcontext
   when:
     - ansible_selinux is defined
     - ansible_selinux.status == "enabled"
-  notify:
-    - Set correct context
+
+- name: "Set correct context"
+  ansible.builtin.command: restorecon -R {{ squid_cache_dir2["path"] }}
+  changed_when: true
 
 - name: "Template in squid.conf"
   ansible.builtin.template:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -7,7 +7,7 @@
       - policycoreutils-python
       - iproute
     state: "{{ squid_package_state }}"
-  when: ansible_distribution_version == "7"
+  when: ansible_distribution_major_version == "7"
 
 - name: "Install required packages on CentOS8/RHEL8"
   ansible.builtin.dnf:
@@ -15,7 +15,7 @@
       - python3-policycoreutils
       - iproute
     state: "{{ squid_package_state }}"
-  when: ansible_distribution_version == "8"
+  when: ansible_distribution_major_version == "8"
 
 - name: "Install required packages on RHEL9/CentOS9-stream"
   ansible.builtin.dnf:
@@ -23,7 +23,7 @@
       - python3-policycoreutils
       - iproute
     state: "{{ squid_package_state }}"
-  when: ansible_distribution_version == "8"
+  when: ansible_distribution_major_version == "9"
 
 - name: "Set up extra cache dir"
   ansible.builtin.file:


### PR DESCRIPTION
"Set correct context" handler was moved to a task because it needs to be run before the squid can be started.

Centos7 is EOL is removing the support for it.

Checking towards ansible_distribution_major_version instead of ansible_distribution_version, because we want to install required packages also if the ansible_distribution_version is "9.5".

We want to run selinux related task when ansible_selinux is true (variable contains data) or ansible_selinux is defined, not when ansible_selinux is false.